### PR TITLE
make instructions more useful to newcomers

### DIFF
--- a/README
+++ b/README
@@ -7,6 +7,8 @@ cd openwrt-ib42x0
 cp default-config .config
 scripts/feeds update
 scripts/feeds install
+make package/symlinks
+make
 
 If you want to update afterwards at any time then just run
 


### PR DESCRIPTION
to build openwrt you also need
make package/symlinks
make

skipping "make package/symlinks bb/loginutils" will
cause a build failure due to an unresolved dependency on libpam.
